### PR TITLE
Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![codez logo](codez.png)
 
-## Codez 
+## Codez
 
 Codez is a library designed to help ease the process of generating codes for your end users that can be helpful for confirmation numbers, reservation systems, error codes, and more.
 
@@ -8,9 +8,9 @@ Codez is a library designed to help ease the process of generating codes for you
 
 > dotnet add package Codez
 
-## CodeGenerator
+## Code Generators (ICodeGenerator)
 
-The core of the library is the `CodeGenerator` class, which has two methods: `GenerateAsync` and `TryGenerateAsync`. The `CodeGenerator` class is made up of several dependencies that can change the behavior of the generate methods:
+The core of the library is the `ICodeGenerator` interface, which has two methods: `GenerateAsync` and `TryGenerateAsync`. You can also implement your own code generator by inheriting from `CodeGeneratorBase`. The `CodeGeneratorBase` class is made up of several dependencies that can change the behavior of the generate methods:
 
 - Alphabet (`IAlphabet`)
 - Randomizer (`IRandomizer`)
@@ -18,8 +18,9 @@ The core of the library is the `CodeGenerator` class, which has two methods: `Ge
 - Stop Words (`IStopWords`)
 - Options (`CodeGeneratorOptions`)
 - Transformers (`ITransformer`)
+- Listeners (`IListener`)
 
-Each dependency is explained in detail below. Codez also comes with some defaults out of the box if you don't want to customize anything.
+Each dependency is explained in detail below. If you don't want to customize anything, Codez also comes with some generators and dependencies out of the box. Some generators in the Codez package are `CodeGenerator` and `NonRepeatingCodeGenerator`.
 
 ### GenerateAsync
 
@@ -78,9 +79,16 @@ The transformer (`ITransfomer`) interface allows you to take a uniquely generate
 
 There is a sample in which this libary is used to [generate unique container names](https://github.com/khalidabuhakmeh/codez/blob/master/test/Tests/TransformerTests.cs).
 
+### IListener
+
+The `IListener` interface can be implemented on any of the dependencies of a code generator. In `CodeGeneratorBase` all dependencies that implement the interface will will be called twice: `OnBeforeAttempt` and `OnAfterAttempt`. This gives you an oppurtunity to hook into the attempt process.
+
 ### Options
 
 Options allow you to alter the behavior of the code generation:
 
 - Retry Limit (default of 5): Number of iterations to attempt generation
 
+## Contributors
+
+- [Tim VanFosson](https://github.com/tvanfosson)

--- a/src/Codez/Alphabets/ExclusiveStringAlphabet.cs
+++ b/src/Codez/Alphabets/ExclusiveStringAlphabet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Codez.Listeners;
 
 namespace Codez.Alphabets
 {

--- a/src/Codez/Codez.csproj
+++ b/src/Codez/Codez.csproj
@@ -26,4 +26,19 @@
       <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0-preview.18571.3" />
     </ItemGroup>
 
+
+    <ItemGroup>
+      <Compile Remove="artifacts\**" />
+    </ItemGroup>
+
+
+    <ItemGroup>
+      <EmbeddedResource Remove="artifacts\**" />
+    </ItemGroup>
+
+
+    <ItemGroup>
+      <None Remove="artifacts\**" />
+    </ItemGroup>
+
 </Project>

--- a/src/Codez/Generators/CodeGenerator.cs
+++ b/src/Codez/Generators/CodeGenerator.cs
@@ -12,11 +12,11 @@ namespace Codez.Generators
     /// <summary>
     /// Default Code Generator
     /// </summary>
-    public class DefaultCodeGenerator : CodeGeneratorBase, ICodeGenerator
+    public class CodeGenerator : CodeGeneratorBase, ICodeGenerator
     {
         private readonly StringBuilder sb = new StringBuilder();
 
-        public DefaultCodeGenerator(CodeGeneratorOptions options = null,
+        public CodeGenerator(CodeGeneratorOptions options = null,
                                 IAlphabet alphabet = null ,
                                 IRandomizer randomizer = null,
                                 IUniqueness uniqueness = null, 

--- a/src/Codez/Generators/CodeGeneratorBase.cs
+++ b/src/Codez/Generators/CodeGeneratorBase.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Codez.Alphabets;
+using Codez.Listeners;
 using Codez.Randomizers;
 using Codez.StopWords;
 using Codez.Transformers;
 using Codez.Uniques;
 
-namespace Codez
+namespace Codez.Generators
 {
     public abstract class CodeGeneratorBase
     {

--- a/src/Codez/Generators/CodeGeneratorException.cs
+++ b/src/Codez/Generators/CodeGeneratorException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Codez
+namespace Codez.Generators
 {
     public class CodeGeneratorException : Exception
     {

--- a/src/Codez/Generators/CodeGeneratorOptions.cs
+++ b/src/Codez/Generators/CodeGeneratorOptions.cs
@@ -1,4 +1,4 @@
-namespace Codez
+namespace Codez.Generators
 {
     public class CodeGeneratorOptions
     {

--- a/src/Codez/Generators/CodeGeneratorResult.cs
+++ b/src/Codez/Generators/CodeGeneratorResult.cs
@@ -1,4 +1,4 @@
-namespace Codez
+namespace Codez.Generators
 {
     public class CodeGeneratorResult
     {

--- a/src/Codez/Generators/DefaultCodeGenerator.cs
+++ b/src/Codez/Generators/DefaultCodeGenerator.cs
@@ -1,20 +1,22 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Codez.Alphabets;
+using Codez.Listeners;
 using Codez.Randomizers;
 using Codez.StopWords;
 using Codez.Transformers;
 using Codez.Uniques;
 
-namespace Codez
+namespace Codez.Generators
 {
-    public class CodeGenerator : CodeGeneratorBase, ICodeGenerator
+    /// <summary>
+    /// Default Code Generator
+    /// </summary>
+    public class DefaultCodeGenerator : CodeGeneratorBase, ICodeGenerator
     {
         private readonly StringBuilder sb = new StringBuilder();
 
-        public CodeGenerator(CodeGeneratorOptions options = null,
+        public DefaultCodeGenerator(CodeGeneratorOptions options = null,
                                 IAlphabet alphabet = null ,
                                 IRandomizer randomizer = null,
                                 IUniqueness uniqueness = null, 

--- a/src/Codez/Generators/FailureReasonType.cs
+++ b/src/Codez/Generators/FailureReasonType.cs
@@ -1,4 +1,4 @@
-namespace Codez
+namespace Codez.Generators
 {
     public enum FailureReasonType
     {

--- a/src/Codez/Generators/ICodeGenerator.cs
+++ b/src/Codez/Generators/ICodeGenerator.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 
-namespace Codez
+namespace Codez.Generators
 {
     public interface ICodeGenerator
     {

--- a/src/Codez/Generators/NonRepeatingCodeGenerator.cs
+++ b/src/Codez/Generators/NonRepeatingCodeGenerator.cs
@@ -1,17 +1,16 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-
 using Codez.Alphabets;
 using Codez.Randomizers;
 using Codez.StopWords;
 using Codez.Transformers;
 using Codez.Uniques;
 
-namespace Codez
+namespace Codez.Generators
 {
-    public class NonrepeatingCodeGenerator : CodeGeneratorBase, ICodeGenerator
+    public class NonRepeatingCodeGenerator : CodeGeneratorBase, ICodeGenerator
     {
-        public NonrepeatingCodeGenerator(CodeGeneratorOptions options = null,
+        public NonRepeatingCodeGenerator(CodeGeneratorOptions options = null,
                              IAlphabet alphabet = null,
                              IRandomizer randomizer = null,
                              IUniqueness uniqueness = null,

--- a/src/Codez/Listeners/AfterAttemptEvent.cs
+++ b/src/Codez/Listeners/AfterAttemptEvent.cs
@@ -1,13 +1,7 @@
-using System.Threading.Tasks;
+using Codez.Generators;
 
-namespace Codez
+namespace Codez.Listeners
 {
-    public interface IListener
-    {
-        Task OnBeforeAttempt(BeforeAttemptEvent @event);
-        Task OnAfterAttempt(AfterAttemptEvent @event);
-    }
-
     public class AfterAttemptEvent
     {
         public AfterAttemptEvent(CodeGeneratorResult result)
@@ -22,15 +16,5 @@ namespace Codez
         }
 
         public CodeGeneratorResult Result { get; }
-    }
-
-    public class BeforeAttemptEvent
-    {
-        public BeforeAttemptEvent(int attempt)
-        {
-            Attempt = attempt;
-        }
-        
-        public int Attempt { get; }
     }
 }

--- a/src/Codez/Listeners/BeforeAttemptEvent.cs
+++ b/src/Codez/Listeners/BeforeAttemptEvent.cs
@@ -1,0 +1,12 @@
+namespace Codez.Listeners
+{
+    public class BeforeAttemptEvent
+    {
+        public BeforeAttemptEvent(int attempt)
+        {
+            Attempt = attempt;
+        }
+        
+        public int Attempt { get; }
+    }
+}

--- a/src/Codez/Listeners/IListener.cs
+++ b/src/Codez/Listeners/IListener.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Codez.Listeners
+{
+    public interface IListener
+    {
+        Task OnBeforeAttempt(BeforeAttemptEvent @event);
+        Task OnAfterAttempt(AfterAttemptEvent @event);
+    }
+}

--- a/src/Codez/Transformers/ITransformer.cs
+++ b/src/Codez/Transformers/ITransformer.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Codez.Generators;
 
 namespace Codez.Transformers
 {

--- a/src/Codez/Uniques/InMemoryUniqueness.cs
+++ b/src/Codez/Uniques/InMemoryUniqueness.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Codez.Listeners;
 
 namespace Codez.Uniques
 {

--- a/test/Tests/CodeGeneratorTestContext.cs
+++ b/test/Tests/CodeGeneratorTestContext.cs
@@ -2,6 +2,7 @@
 
 using Codez;
 using Codez.Alphabets;
+using Codez.Generators;
 using Codez.Randomizers;
 using Codez.StopWords;
 using Codez.Transformers;

--- a/test/Tests/CodeGeneratorTests.cs
+++ b/test/Tests/CodeGeneratorTests.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace Tests
 {
-    public class CodeGeneratorTests : CodeGeneratorTestsBase<DefaultCodeGenerator>
+    public class CodeGeneratorTests : CodeGeneratorTestsBase<CodeGenerator>
     {
         public CodeGeneratorTests(ITestOutputHelper output) 
             : base(output)

--- a/test/Tests/CodeGeneratorTests.cs
+++ b/test/Tests/CodeGeneratorTests.cs
@@ -1,11 +1,11 @@
 ﻿
 using Codez;
-
+using Codez.Generators;
 using Xunit.Abstractions;
 
 namespace Tests
 {
-    public class CodeGeneratorTests : CodeGeneratorTestsBase<CodeGenerator>
+    public class CodeGeneratorTests : CodeGeneratorTestsBase<DefaultCodeGenerator>
     {
         public CodeGeneratorTests(ITestOutputHelper output) 
             : base(output)

--- a/test/Tests/CodeGeneratorTestsBase.cs
+++ b/test/Tests/CodeGeneratorTestsBase.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 
 using Codez;
 using Codez.Alphabets;
+using Codez.Generators;
 using Codez.StopWords;
 using Codez.Uniques;
 

--- a/test/Tests/ListenerTests.cs
+++ b/test/Tests/ListenerTests.cs
@@ -1,6 +1,8 @@
 using System.Threading.Tasks;
 using Codez;
 using Codez.Alphabets;
+using Codez.Generators;
+using Codez.Listeners;
 using Xunit;
 
 namespace Tests
@@ -11,7 +13,7 @@ namespace Tests
         public async Task Can_listen_for_attempts()
         {
             var alphabet = new CountingAlphabet();
-            var generator = new CodeGenerator(alphabet: alphabet);
+            var generator = new DefaultCodeGenerator(alphabet: alphabet);
             
             Assert.Equal(0, alphabet.Attempts);
 

--- a/test/Tests/ListenerTests.cs
+++ b/test/Tests/ListenerTests.cs
@@ -13,7 +13,7 @@ namespace Tests
         public async Task Can_listen_for_attempts()
         {
             var alphabet = new CountingAlphabet();
-            var generator = new DefaultCodeGenerator(alphabet: alphabet);
+            var generator = new CodeGenerator(alphabet: alphabet);
             
             Assert.Equal(0, alphabet.Attempts);
 

--- a/test/Tests/NonrepeatingCodeGeneratorTests.cs
+++ b/test/Tests/NonrepeatingCodeGeneratorTests.cs
@@ -2,13 +2,13 @@
 
 using Codez;
 using Codez.Alphabets;
-
+using Codez.Generators;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Tests
 {
-    public class NonrepeatingCodeGeneratorTests : CodeGeneratorTestsBase<NonrepeatingCodeGenerator>
+    public class NonrepeatingCodeGeneratorTests : CodeGeneratorTestsBase<NonRepeatingCodeGenerator>
     {
         public NonrepeatingCodeGeneratorTests(ITestOutputHelper output) 
             : base(output)
@@ -22,7 +22,7 @@ namespace Tests
             var alphabet = new AsciiAlphabet();
             var length = alphabet.Count + 1;
 
-            var generator = _c.CreateGenerator<NonrepeatingCodeGenerator>(alphabet: alphabet);
+            var generator = _c.CreateGenerator<NonRepeatingCodeGenerator>(alphabet: alphabet);
 
             var result = await generator.TryGenerateAsync(length);
 

--- a/test/Tests/TransformerTests.cs
+++ b/test/Tests/TransformerTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Codez;
 using Codez.Alphabets;
+using Codez.Generators;
 using Codez.Transformers;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,7 +21,7 @@ namespace Tests
         [Fact]
         public async Task Can_generate_and_transform_to_container_names()
         {
-            var generator = new CodeGenerator(
+            var generator = new DefaultCodeGenerator(
                 alphabet: new StringAlphabet("0123456789"),
                 transformer: new ContainerNamesTransformer()
             );
@@ -36,7 +37,7 @@ namespace Tests
         [Fact]
         public async Task Can_fail_to_transform()
         {
-            var generator = new CodeGenerator(
+            var generator = new DefaultCodeGenerator(
                 alphabet: new StringAlphabet("0123456789"),
                 transformer: new ContainerNamesTransformer()
             );

--- a/test/Tests/TransformerTests.cs
+++ b/test/Tests/TransformerTests.cs
@@ -21,7 +21,7 @@ namespace Tests
         [Fact]
         public async Task Can_generate_and_transform_to_container_names()
         {
-            var generator = new DefaultCodeGenerator(
+            var generator = new CodeGenerator(
                 alphabet: new StringAlphabet("0123456789"),
                 transformer: new ContainerNamesTransformer()
             );
@@ -37,7 +37,7 @@ namespace Tests
         [Fact]
         public async Task Can_fail_to_transform()
         {
-            var generator = new DefaultCodeGenerator(
+            var generator = new CodeGenerator(
                 alphabet: new StringAlphabet("0123456789"),
                 transformer: new ContainerNamesTransformer()
             );


### PR DESCRIPTION
- Generators namespace with rename of CodeGenerator -> DefaultCodeGenerator
- Moved items into files and new namespaces
- updated tests

This is kind of a breaking change since nothing is in the default namespace
but I think it is nice having multiple code generators.